### PR TITLE
Concat seems have issues on our repos. Maybe due to empty array?

### DIFF
--- a/db/reporting/db_report_repo_unowned.rb
+++ b/db/reporting/db_report_repo_unowned.rb
@@ -41,7 +41,10 @@ class RepoUnownedDbReporter < DbReporter
     noteam=sync_db["SELECT r.name, r.created_at FROM repository r WHERE r.id NOT IN (SELECT DISTINCT repository_id FROM team_to_repository) AND r.org=?", org]
 
     text = ''
-    emptyteam.concat(noteam).each do |row|
+    emptyteam.each do |row|
+      text << "  <reporting class='repo-report' repo='#{org}/#{row[:name]}' type='RepoUnownedDbReporter'><field>#{row[:created_at]}</field><field>#{org}/#{row[:name]}</field></reporting>\n"
+    end
+    noteam.each do |row|
       text << "  <reporting class='repo-report' repo='#{org}/#{row[:name]}' type='RepoUnownedDbReporter'><field>#{row[:created_at]}</field><field>#{org}/#{row[:name]}</field></reporting>\n"
     end
 


### PR DESCRIPTION
Ruby Rookie here - no idea what went wrong, the complaint I got was that concat cannot be called on the object it was called on. My suspicion is that maybe one of the arrays was empty. Posting this as a demonstration of where the issue is, the ultimate fix probably needs to be a different one.