### PR TITLE
add option for ignoring ssl_verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Example file:
 ```
  github:
    access_token: 'your github personal access token'
+   ssl_verify: false
 ```
 
 For general use, no specific scopes are required. If you wish to see private organization data (such as Teams, all Members and private Repositories), you will need to enable the 'repo' scope.

--- a/refresh-dashboard.rb
+++ b/refresh-dashboard.rb
@@ -67,13 +67,17 @@ else
 end
 
 # GitHub setup
-if(ENV['GH_ACCESS_TOKEN'])
-  access_token=ENV['GH_ACCESS_TOKEN']
-elsif(options[:ghconfig])
+access_token = ENV['GH_ACCESS_TOKEN']
+
+if(options[:ghconfig])
   config_file = options[:ghconfig]
   config = YAML.load(File.read(config_file))
-  access_token = config['github']['access_token']
-else
+
+  access_token ||= config['github']['access_token']
+  ssl_verify = config['github']['ssl_verify'] || false
+end
+
+if(access_token.nil?)
   puts "ERROR: Need a GitHub access token, either via environment variable (GH_ACCESS_TOKEN) or configuration file. "
   puts "Usages: \n    GH_ACCESS_TOKEN=... #{$0} <dashboard-config> [optional-phase]\n    #{$0} --ghconfig <file> <dashboard-config> [optional-phase]"
   exit
@@ -81,6 +85,7 @@ end
 
 Octokit.auto_paginate = true
 client = Octokit::Client.new :access_token => access_token
+client.connection_options[:ssl] = {:verify => ssl_verify}
 
 # Dashboard configuration
 config_file = ARGV[0]


### PR DESCRIPTION
I encountered an error when requesting to ghe, because our GitHub Enterprise uses self-signed certificate.
So we need the option for ignoring ssl_verify.