### PR TITLE
Reomove descriptions for missing constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For an example file, see
     logins: ['hyandell']
     data-directory: /full/path/to/directory/to/store/data
     reports: [ 'DocsReporter', 'LicenseReporter', 'BinaryReporter' ]
-    db-reports: [ 'UnknownCollaboratorsDbReporter', 'LeftEmploymentDbReporter', 'UnknownMembersDbReporter', 'WikiOnDbReporter', 'EmptyDbReporter', 'UnchangedDbReporter', 'NoIssueCommentsDbReporter', 'NoPrCommentsDbReporter', 'RepoUnownedDbReporter', 'LabelDbReporter', 'AverageIssueCloseDbReporter', 'AveragePrCloseDbReporter', 'AverageIssueOpenedDbReporter', 'AveragePrOpenedDbReporter' ]
+    db-reports: [ 'UnknownCollaboratorsDbReporter', 'LeftEmploymentDbReporter', 'UnknownMembersDbReporter', 'WikiOnDbReporter', 'EmptyDbReporter', 'UnchangedDbReporter', 'NoIssueCommentsDbReporter', 'NoPrCommentsDbReporter', 'RepoUnownedDbReporter', 'LabelDbReporter', 'AverageIssueCloseDbReporter', 'AveragePrCloseDbReporter' ]
     www-directory: /full/path/to/generate/html/to
 
     private-access: ['amznlabs']     # Optional


### PR DESCRIPTION
`AverageIssueOpenedDbReporter` and `AverageIssueOpenedDbReporter` were removed by this [PR](https://github.com/amzn/oss-dashboard/commit/320da7e5f84d08911ff44fb60ae5599155308780#diff-c94b8ae935567acd73363d0c4737be77)
But the description about that keyword remains in README.md(I encountered the error caused by using that constant).

It should be removed.