### PR TITLE
Move Dir.mkdir for www-direcotry

### DIFF
--- a/refresh-dashboard.rb
+++ b/refresh-dashboard.rb
@@ -125,6 +125,9 @@ www_directory = dashboard_config['www-directory']
 unless(File.exists?(data_directory))
   Dir.mkdir(data_directory)
 end
+unless(File.exists?(www_directory))
+  Dir.mkdir(www_directory)
+end
 
 if(options[:light] and ARGV[1])
   puts "Light mode does not allow specific phases to be called. "
@@ -252,10 +255,6 @@ run_list.each do |phase|
     end
 
     if(phase=='generate-dashboard' or phase=='generate-dashboard/xslt')
-      unless(File.exists?(www_directory))
-        Dir.mkdir(www_directory)
-      end
-
       # xslt the dashboards
       context.feedback.print " xslt (dashboards) "
       xml2html(context, "#{data_directory}/dash-xml/*.xml", File.join( File.dirname(__FILE__), 'generate-dashboard', 'style', 'dashboardToHtml.xslt'), www_directory)


### PR DESCRIPTION
I encountered the following error.

```
generate-dashboard
 json-data
  kaakaa /oss-dashboard/generate-dashboard/generate-json-data.rb:116:in `mkdir': No such file or directory @ dir_s_mkdir - html/json-data (Errno::ENOENT)
	from /oss-dashboard/generate-dashboard/generate-json-data.rb:116:in `block in generate_json_data'
	from /oss-dashboard/generate-dashboard/generate-json-data.rb:111:in `each'
	from /oss-dashboard/generate-dashboard/generate-json-data.rb:111:in `generate_json_data'
	from refresh-dashboard.rb:237:in `block in <main>'
	from refresh-dashboard.rb:193:in `each'
	from refresh-dashboard.rb:193:in `<main>'
```

In about 10 days ago `generate_json_data` method added in this commit (
[Overhaul to the dashboards to a) make charts more pluggable via separ… · amzn/oss-dashboard@8486704](https://github.com/amzn/oss-dashboard/commit/8486704d6b7ac5227f576e1f7e2cc026b8f85deb))

`generate_json_data` method needs directory of `www_directory`.
But `Dir.mkdir(www_directory)` is called after calling `generate_json_data` method in `refresh-dashboard.rb`.

So `Dir.mkdir(www_directory)` should be called before calling `generate_json_data`.