### PR TITLE
Fix accessing team stats when private access is granted.

### DIFF
--- a/github-sync/db_metadata/sync-metadata.rb
+++ b/github-sync/db_metadata/sync-metadata.rb
@@ -117,7 +117,7 @@ def store_organization_members(db, client, org_obj, private, previous_members)
   # Get collaborators too - no organization API :(
   # TODO: Does this work for personal accounts or just organizations?
   if(private)
-    client.repositories(org_obj.name).each do |repo_obj|
+    client.repositories(org_obj.login).each do |repo_obj|
       collaborators=client.collaborators(repo_obj.full_name)
       collaborators.each do |collaborator|
         unless(previous_members[collaborator.id])


### PR DESCRIPTION
The original implementation looks like it's using the org name
instead of the org login name to access collaborator stats.

This breaks if these two strings aren't identical.

The attached change fixed the behaviour for me, not sure if there's a better location (or if there are other locations that might break similarly).

*Issue #, if available:*
#111

*Please confirm that your contribution is made under the terms of the Apache 2.0 license:*
Confirming.