### PR TITLE
Handle 409 Conflict error

### DIFF
--- a/github-sync-tng/sync.rb
+++ b/github-sync-tng/sync.rb
@@ -59,6 +59,9 @@ def eval_queue(queue, context, sync_db)
       queue.push(cmd)
       return_code=false
       break
+    rescue Octokit::Conflict => msg
+      context.feedback.puts "!"
+      return false
     rescue Faraday::TimeoutError => msg
       puts "GitHub API timing out, pushing command back on queue: #{msg}"
       queue.push(cmd)


### PR DESCRIPTION
*Issue #, if available: #102 

*Description of changes:
When octokit returns 409 conflict, treating it as `passed=false` and don't put back on queue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

NOTE:
  [This repository](https://github.com/kaakaa/WatchrPlugin_trac) returns `size: 56` through REST API, but has no commit(empty repository).
  And some non-empty repository may return `size: 0` (ex. [repo](https://github.com/kaakaa/drone-ci-sample)).
  Since such behavior is strange to me, I am contacting GitHub support for that, but the answer has not come yet.
