### PR TITLE
Fix to update same daily-traffic-data entry

### DIFF
--- a/db/lib/trafficStoreLibrary.rb
+++ b/db/lib/trafficStoreLibrary.rb
@@ -83,6 +83,10 @@ require "date"
           ].insert
         views['views'].each do |view|
             db[
+              "DELETE FROM traffic_views_daily WHERE org=? AND repo=? AND timestamp=?",
+              org, repo, gh_to_db_timestamp(view['timestamp'])
+              ].delete
+            db[
              "INSERT INTO traffic_views_daily (
                 org, repo, count, uniques, timestamp
               )
@@ -113,17 +117,21 @@ require "date"
           clones['uniques']
           ].insert
         clones['clones'].each do |clone|
-            db[
-             "INSERT INTO traffic_clones_daily (
-                org, repo, count, uniques, timestamp
-              )
-              VALUES ( ?, ?, ?, ?, ? )",
-              org,
-              repo,
-              clone['count'],
-              clone['uniques'],
-              gh_to_db_timestamp(clone['timestamp'])
-              ].insert
+          db[
+            "DELETE FROM traffic_clones_daily WHERE org=? AND repo=? AND timestamp=?",
+            org, repo, gh_to_db_timestamp(clone['timestamp'])
+            ].delete
+          db[
+           "INSERT INTO traffic_clones_daily (
+              org, repo, count, uniques, timestamp
+            )
+            VALUES ( ?, ?, ?, ?, ? )",
+            org,
+            repo,
+            clone['count'],
+            clone['uniques'],
+            gh_to_db_timestamp(clone['timestamp'])
+            ].insert
         end
       end
     rescue => e


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes:
Per executing, data for the two weeks is added to the `traffic_views_daily` and `traffic_clones_daily` table even if data of the same org/repo/timestamp already exists.
For this reason, there were multiple duplicated data in that tables.

If data of the same org, repo, timestamp exist before adding data, delete it and add new one, so that duplication of entries is avoided.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
