### PR TITLE
Make the dashboard service wait until the db is available.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM gesellix/wait-for:latest as wait-for
-
 FROM ruby:2.2.6-slim
 
-COPY --from=wait-for /wait-for /wait-for
 RUN apt update && apt install --no-install-recommends -y \
   build-essential \
   cmake \
@@ -15,6 +12,10 @@ RUN apt update && apt install --no-install-recommends -y \
   pkg-config \
   postgresql \
   netcat \
+  curl \
+  && curl -o /wait-for https://raw.githubusercontent.com/Eficode/wait-for/master/wait-for \
+  && chmod +x /wait-for \
+  && apt-get remove -y curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,6 @@ RUN apt update && apt install --no-install-recommends -y \
   pkg-config \
   postgresql \
   netcat \
-  curl \
-  && curl -o /wait-for https://raw.githubusercontent.com/Eficode/wait-for/master/wait-for \
-  && chmod +x /wait-for \
-  && apt-get remove -y curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     volumes:
-      - ./postgres:/var/lib/postgresql/data
+      - oss-dashboard-postgres:/var/lib/postgresql/data
+    networks:
+      - db
   dashboard:
     build:
       context: ./
@@ -18,11 +20,18 @@ services:
     environment:
       - GH_ACCESS_TOKEN=
       - OCTOKIT_API_ENDPOINT= # if you use oss-dashboard to GitHub Enterprise, specify GHE api endpoint (ex. https://github.mycompany.com/api/v3)
+    entrypoint: /wait-for db:5432 -t 10 -- bundle exec ruby
     command: refresh-dashboard.rb config-dashboard.yaml
     volumes:
       - ./config-dashboard.yaml:/oss-dashboard/config-dashboard.yaml
       # - ./config-github.yaml:/oss-dashboard/config-github.yaml
       - ./data:/oss-dashboard/data
       - ./html:/oss-dashboard/html
-    links:
+    networks:
       - db
+
+networks:
+  db:
+
+volumes:
+  oss-dashboard-postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
         - http_proxy
         - https_proxy
     environment:
-      - GH_ACCESS_TOKEN=
-      - OCTOKIT_API_ENDPOINT= # if you use oss-dashboard to GitHub Enterprise, specify GHE api endpoint (ex. https://github.mycompany.com/api/v3)
+      - GH_ACCESS_TOKEN
+      - OCTOKIT_API_ENDPOINT # if you use oss-dashboard to GitHub Enterprise, specify GHE api endpoint (ex. https://github.mycompany.com/api/v3)
     entrypoint: /wait-for db:5432 -t 10 -- bundle exec ruby
     command: refresh-dashboard.rb config-dashboard.yaml
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     environment:
       - GH_ACCESS_TOKEN
       - OCTOKIT_API_ENDPOINT # if you use oss-dashboard to GitHub Enterprise, specify GHE api endpoint (ex. https://github.mycompany.com/api/v3)
-    entrypoint: /wait-for db:5432 -t 10 -- bundle exec ruby
+    entrypoint: /oss-dashboard/wait-for.sh db:5432 -t 10 -- bundle exec ruby
     command: refresh-dashboard.rb config-dashboard.yaml
     volumes:
       - ./config-dashboard.yaml:/oss-dashboard/config-dashboard.yaml

--- a/wait-for.sh
+++ b/wait-for.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2017 Eficode Oy
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Taken from https://github.com/Eficode/wait-for
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION
*Description of changes:*

This commit introduces a script (wait-for) in the Dashboard Dockerfile to delay the dashboard startup until the Postgres db is available. It is already added to the `docker-compose.yml`.

Additionally, I reordered some Dockerfile statements to leverage the implicit Docker layer cache. This allows a better roundtrip when developing locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
