### PR TITLE
Include pull request reviews in database

### DIFF
--- a/github-sync-tng/issue_comment_command.rb
+++ b/github-sync-tng/issue_comment_command.rb
@@ -60,10 +60,13 @@ class SyncItemCommentsCommand < BaseCommand
         # Increment the timestamp by a second to avoid getting repeats
         ts=DateTime.strptime(maxTimestamp, '%Y-%m-%dT%H:%M:%S') + Rational(1, 60 * 60 * 24)
         comments=context.client.issues_comments(orgrepo, { 'since' => ts } )
+	pr_reviews=context.client.pull_requests_comments(orgrepo, { 'since' => ts } )
       else
         comments=context.client.issues_comments(orgrepo)
+	pr_reviews=context.client.pull_requests_comments(orgrepo)
       end
       db_insert_comments(issue_db, comments, org, repo)
+      db_insert_pr_reviews(issue_db, pr_reviews, org, repo)
     end
   end
 

--- a/github-sync/db_issues/sync-issues.rb
+++ b/github-sync/db_issues/sync-issues.rb
@@ -147,10 +147,13 @@ def getLatestIssueComments(context, issue_db, org, repos)
           # Increment the timestamp by a second to avoid getting repeats
           ts=DateTime.strptime(maxTimestamp, '%Y-%m-%dT%H:%M:%S') + Rational(1, 60 * 60 * 24)
           comments=context.client.issues_comments(repo_obj.full_name, { 'since' => ts } )
+	  pr_reviews=context.client.pull_requests_comments(repo_obj.full_name, { 'since' => ts } )
         else
           comments=context.client.issues_comments(repo_obj.full_name)
+	  pr_reviews=context.client.pull_requests_comments(repo_obj.full_name)
         end
         db_insert_comments(issue_db, comments, org, repo_obj.name)
+        db_insert_pr_reviews(issue_db, pr_reviews, org, repo_obj.name)
       end
       context.feedback.print '.'
     end
@@ -171,3 +174,4 @@ def sync_issue_comments(context, sync_db)
   end
 
 end
+


### PR DESCRIPTION
Problem description: When commenting on pull requests, Github offers the option to bundle several comments together into a pull request review. As far as I can see, those reviews don't make it into the database so far. This PR adds the results of the https://octokit.github.io/octokit.rb/Octokit/Client/PullRequests.html#pull_requests_comments-instance_method call.

See https://github.com/MaineC/sandbox/pull/1 for an example some of the various types of comments that can be made on a pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
