### PR TITLE
Only sync published releases.

### DIFF
--- a/github-sync-tng/release_command.rb
+++ b/github-sync-tng/release_command.rb
@@ -80,14 +80,16 @@ class SyncReleaseCommand < BaseCommand
               end
           end
 
-
-          db[
-           "INSERT INTO releases (
-              org, repo, id, html_url, tarball_url, zipball_url, tag_name, name, body, created_at, published_at, author
-            )
-            VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
-            org, repo, release.id, release.html_url, release.tarball_url, release.zipball_url, release.tag_name, release.name, release.body, release.created_at.to_s,
-            release.published_at.to_s, author].insert
+	  # only include releases that were published
+	  if(release.published_at)
+	          db[
+        	   "INSERT INTO releases (
+	              org, repo, id, html_url, tarball_url, zipball_url, tag_name, name, body, created_at, published_at, author
+	            )
+	            VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
+	            org, repo, release.id, release.html_url, release.tarball_url, release.zipball_url, release.tag_name, release.name, release.body, release.created_at.to_s,
+	            release.published_at.to_s, author].insert
+	  end
       end
     end
   end

--- a/github-sync/db_releases/sync-releases.rb
+++ b/github-sync/db_releases/sync-releases.rb
@@ -35,13 +35,16 @@ def db_insert_releases(db, org, repo, releases)
           end
       end
 
-      db[
-       "INSERT INTO releases (
-          org, repo, id, html_url, tarball_url, zipball_url, tag_name, name, body, created_at, published_at, author
-        )
-        VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
-        org, repo, release.id, release.html_url, release.tarball_url, release.zipball_url, release.tag_name,
-        release.name, release.body, release.created_at.to_s, release.published_at.to_s, author].insert
+      # only track published releases
+      if(release.published_at)
+	db[
+          "INSERT INTO releases (
+            org, repo, id, html_url, tarball_url, zipball_url, tag_name, name, body, created_at, published_at, author
+          )
+          VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
+          org, repo, release.id, release.html_url, release.tarball_url, release.zipball_url, release.tag_name,
+          release.name, release.body, release.created_at.to_s, release.published_at.to_s, author].insert
+      end
   end
 end
 


### PR DESCRIPTION
The current code for syncing releases breaks if there are repositories that contain unpublished/ draft releases. This introduces a change to *ignore* those releases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
