### PR TITLE
Dockerfile using ruby 2.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.6-slim
+FROM ruby:2.4.5
 
 RUN apt update && apt install --no-install-recommends -y \
   build-essential \


### PR DESCRIPTION
*Issue https://github.com/amzn/oss-dashboard/issues/134

*Description of changes:*
This fixes two problems with the Docker image:

First, the ruby base version was using a jessee image that couldn't install packages anymore:

```
Fetched 10.2 MB in 10s (969 kB/s)
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt update && apt install --no-install-recommends -y   build-essential   cmake   file   git   libpq-dev   libxml2-dev   libxslt1-dev   libssl-dev   pkg-config   postgresql   netcat   && apt-get clean   && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```

The second, when trying to install the gem, the message:

`Your Ruby version is 2.2.6, but your Gemfile specified 2.4.5`

was shown.

---

This still doesn't solve the issue https://github.com/amzn/oss-dashboard/issues/134, but it's a part of it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
