### PR TITLE
Add tracking of whether repos are archived/ disabled

### DIFF
--- a/db/schemas/db_metadata_schema.sql
+++ b/db/schemas/db_metadata_schema.sql
@@ -38,6 +38,8 @@ CREATE TABLE repository (
   created_at TIMESTAMP,
   updated_at TIMESTAMP,
   pushed_at TIMESTAMP,
+  archived BOOLEAN,
+  disabled BOOLEAN,
   size INTEGER,
   description VARCHAR
 );

--- a/github-sync-tng/metadata_command.rb
+++ b/github-sync-tng/metadata_command.rb
@@ -190,10 +190,12 @@ class SyncOrgReposMDCommand < BaseCommand
     db.transaction do
       db["DELETE FROM repository WHERE id=?", repo_obj.id].delete
       db["INSERT INTO repository
-        (id, org, name, homepage, fork, private, has_wiki, language, stars, watchers, forks, created_at, updated_at, pushed_at, size, description)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (id, org, name, homepage, fork, private, has_wiki, language, stars, watchers, forks, created_at, updated_at, pushed_at, archived, disabled, size, description)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         repo_obj.id, org, repo_obj.name, repo_obj.homepage, repo_obj.fork ? true : false, repo_obj.private ? true : false, repo_obj.has_wiki ? true : false, repo_obj.language,
-        repo_obj.watchers, watchers, repo_obj.forks, repo_obj.created_at.to_s, repo_obj.updated_at.to_s, repo_obj.pushed_at.to_s, repo_obj.size, repo_obj.description].insert
+        repo_obj.watchers, watchers, repo_obj.forks, repo_obj.created_at.to_s, repo_obj.updated_at.to_s, repo_obj.pushed_at.to_s,
+        repo_obj.archived ? true : false, repo_obj.disabled ? true : false,
+        repo_obj.size, repo_obj.description].insert
     end
   end
 

--- a/github-sync/db_metadata/sync-metadata.rb
+++ b/github-sync/db_metadata/sync-metadata.rb
@@ -84,11 +84,12 @@ def store_organization_repositories(context, db, org)
     end
 
     db["INSERT INTO repository
-      (id, org, name, homepage, fork, private, has_wiki, language, stars, watchers, forks, created_at, updated_at, pushed_at, size, description)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      (id, org, name, homepage, fork, private, has_wiki, language, stars, watchers, forks, created_at, updated_at, pushed_at, archived, disabled, size, description)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
       repo_obj.id, org, repo_obj.name, repo_obj.homepage, repo_obj.fork ? true : false, repo_obj.private ? true : false,
       repo_obj.has_wiki ? true : false, repo_obj.language, repo_obj.watchers,
       watchers, repo_obj.forks, repo_obj.created_at.to_s, repo_obj.updated_at.to_s, repo_obj.pushed_at.to_s,
+      repo_obj.archived ? true : false, repo_obj.disabled ? true : false,
       repo_obj.size, repo_obj.description].insert
    rescue Octokit::ClientError
       context.feedback.print "!#{$!}!"


### PR DESCRIPTION
GitHub allows to archive repositories. This changes makes that status available
in the repository meta-data. The goal is to make it easier to spot repositories
that are stale and candidates for archiving.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
